### PR TITLE
Player permissions

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -51,6 +51,18 @@
             "TrackerMaxHeight": {
                 "Name": "Quest-Log Max Höhe",
                 "Hint": "Legt die maximale Höhe (in Pixeln) des Quest-Logs fest, wenn es angedockt ist. Hat keine Auswirkung, wenn schwebend."
+            },
+            "PlayerEdit": {
+                "Name": "Spieler bearbeiten erlauben",
+                "Hint": "Erlaube Spielern, Quests zu bearbeiten. Achtung, dies ermöglicht es den Spielern, Eintragsdaten für Ziele zu sehen, was geheime Ziele offenbaren könnte."
+            },
+            "PlayerCreate": {
+                "Name": "Spieler erstellen erlauben",
+                "Hint": "Erlaube Spielern, Quests zu erstellen."
+            },
+            "PlayersMark": {
+                "Name": "Spielern erlauben, Ziele zu markieren",
+                "Hint": "Erlaube Spielern, Ziele als abgeschlossen, gescheitert oder unvollständig zu markieren."
             }
         },
         "Tracker": {

--- a/lang/de.json
+++ b/lang/de.json
@@ -52,17 +52,17 @@
                 "Name": "Quest-Log Max Höhe",
                 "Hint": "Legt die maximale Höhe (in Pixeln) des Quest-Logs fest, wenn es angedockt ist. Hat keine Auswirkung, wenn schwebend."
             },
-            "PlayerEdit": {
-                "Name": "Spieler bearbeiten erlauben",
-                "Hint": "Erlaube Spielern, Quests zu bearbeiten. Achtung, dies ermöglicht es den Spielern, Eintragsdaten für Ziele zu sehen, was geheime Ziele offenbaren könnte."
-            },
             "PlayerCreate": {
                 "Name": "Spieler erstellen erlauben",
-                "Hint": "Erlaube Spielern, Quests zu erstellen."
+                "Hint": "Erlaube es den Spielern, Quests zu erstellen."
+            },
+            "PlayerEdit": {
+                "Name": "Spielern erlauben, GM-Quests zu bearbeiten",
+                "Hint": "Erlaube es den Spielern, Quests des GM zu bearbeiten. Achtung, dies ermöglicht es den Spielern, die Eingabedaten der Ziele zu sehen, was möglicherweise geheime Ziele enthüllt."
             },
             "PlayersMark": {
-                "Name": "Spielern erlauben, Ziele zu markieren",
-                "Hint": "Erlaube Spielern, Ziele als abgeschlossen, gescheitert oder unvollständig zu markieren."
+                "Name": "Spielern erlauben, GM-Ziele zu markieren",
+                "Hint": "Erlaube es den Spielern, die Ziele der Quests des GM als abgeschlossen, fehlgeschlagen oder unvollständig zu markieren."
             }
         },
         "Tracker": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -51,6 +51,18 @@
             "TrackerMaxHeight": {
                 "Name": "Tracker Max Height",
                 "Hint": "Sets the max height (in pixels) of the tracker while docked. Has no effect if not docked."
+            },
+            "PlayerEdit": {
+                "Name": "Allow Player Edits",
+                "Hint": "Allow players to edit quests. Warning, this will allow players to see objective entry data, potentially revealing secret objectives."
+            },
+            "PlayerCreate": {
+                "Name": "Allow Player Create",
+                "Hint": "Allow players to create quests."
+            },
+            "PlayersMark": {
+                "Name": "Allow Players to Mark Objectives",
+                "Hint": "Allow players to mark objectives as complete, failed, or incomplete."
             }
         },
         "Tracker": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -52,17 +52,17 @@
                 "Name": "Tracker Max Height",
                 "Hint": "Sets the max height (in pixels) of the tracker while docked. Has no effect if not docked."
             },
-            "PlayerEdit": {
-                "Name": "Allow Player Edits",
-                "Hint": "Allow players to edit quests. Warning, this will allow players to see objective entry data, potentially revealing secret objectives."
-            },
             "PlayerCreate": {
                 "Name": "Allow Player Create",
                 "Hint": "Allow players to create quests."
             },
+            "PlayerEdit": {
+                "Name": "Allow Players to Edit GM Quests",
+                "Hint": "Allow players to edit quests made by the GM. Warning, this will allow players to see objective entry data, potentially revealing secret objectives."
+            },
             "PlayersMark": {
-                "Name": "Allow Players to Mark Objectives",
-                "Hint": "Allow players to mark objectives as complete, failed, or incomplete."
+                "Name": "Allow Players to Mark GM Objectives",
+                "Hint": "Allow players to mark the objectives of quests made by the GM as complete, failed, or incomplete."
             }
         },
         "Tracker": {

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
             }
         }
     ],
-    "version": "v0.1.7",
+    "version": "v0.1.8",
     "compatibility": {
         "minimum": "12",
         "verified": "12"
@@ -36,5 +36,5 @@
     "socket": true,
     "url": "https://github.com/MythicPalette/simpler-quests",
     "manifest": "https://github.com/MythicPalette/simpler-quests/releases/latest/download/module.json",
-    "download": "https://github.com/MythicPalette/simpler-quests/releases/download/v0.1.7/module.zip"
+    "download": "https://github.com/MythicPalette/simpler-quests/releases/download/v0.1.8/module.zip"
 }

--- a/module.json
+++ b/module.json
@@ -33,6 +33,7 @@
     "styles": ["styles/style.css", "styles/editor.css", "styles/tracker.css"],
     "minimumCoreVersion": "12",
     "compatibleCoreVersion": "12",
+    "socket": true,
     "url": "https://github.com/MythicPalette/simpler-quests",
     "manifest": "https://github.com/MythicPalette/simpler-quests/releases/latest/download/module.json",
     "download": "https://github.com/MythicPalette/simpler-quests/releases/download/v0.1.7/module.zip"

--- a/scripts/data/database.js
+++ b/scripts/data/database.js
@@ -50,6 +50,11 @@ export class QuestDatabase extends Collection {
                 }
             }
 
+            q.canEdit =
+                game.user.isGM ||
+                Settings.get(Settings.NAMES.PLAYER_EDIT) ||
+                !q.GMQuest;
+
             // Return the quest with modified data.
             return {
                 ...q,
@@ -191,8 +196,16 @@ export class QuestDatabase extends Collection {
     static refresh() {
         this.#quests = Settings.get(Settings.NAMES.QUEST_DB).quests;
 
-        // Verify that all quest objectives have an id
+        // Validate all quest data.
         this.#quests.forEach((q, i) => {
+            // For backwards compatability, if a quest
+            // does not have the GMQuest flag, add it.
+            if (!("GMQuest" in q)) {
+                q.GMQuest = true;
+                console.log(q);
+            }
+
+            //  Ensure that all quest objectives have an id
             if (q.objectives)
                 this.#quests[i] = {
                     ...q,

--- a/scripts/data/database.js
+++ b/scripts/data/database.js
@@ -55,6 +55,9 @@ export class QuestDatabase extends Collection {
                 Settings.get(Settings.NAMES.PLAYER_EDIT) ||
                 !q.GMQuest;
 
+            // Players can never delete GM quests.
+            q.canDelete = game.user.isGM || !q.GMQuest;
+
             // Return the quest with modified data.
             return {
                 ...q,

--- a/scripts/data/quest.js
+++ b/scripts/data/quest.js
@@ -16,6 +16,7 @@ export class Quest {
         this.objectives = [];
         this.viewStyle =
             data.viewStyle || Settings.get(Settings.NAMES.QUEST_VIEW_STYLE);
+        this.GMQuest = data.GMQuest || true; // Default to GM-made quests.
 
         // Go through the objectives in the data and create them.
         if (data.objectives) {

--- a/scripts/data/quest.js
+++ b/scripts/data/quest.js
@@ -16,7 +16,7 @@ export class Quest {
         this.objectives = [];
         this.viewStyle =
             data.viewStyle || Settings.get(Settings.NAMES.QUEST_VIEW_STYLE);
-        this.GMQuest = data.GMQuest || true; // Default to GM-made quests.
+        this.GMQuest = "GMQuest" in data ? data.GMQuest : true; // Default to GM-made quests.
 
         // Go through the objectives in the data and create them.
         if (data.objectives) {

--- a/scripts/helpers/SocketHandler.js
+++ b/scripts/helpers/SocketHandler.js
@@ -2,6 +2,7 @@ import { constants } from "./global.js";
 import { Quest } from "../data/quest.js";
 import { QuestDatabase } from "../data/database.js";
 import { UIManager } from "../ui/ui-manager.js";
+import { Settings } from "./settings.js";
 
 export class SocketHandler {
     identifier = `module.simpler-quests`;
@@ -13,32 +14,60 @@ export class SocketHandler {
     registerSocketListeners() {
         game.socket?.on(this.identifier, (ev) => {
             if (ev.type === "InsertOrUpdate") this.#OnInsertOrUpdate(ev.data);
+            if (ev.type === "DeleteQuest") this.#OnDeleteQuest(ev.data);
             else if (ev.type == "UpdateObjective")
                 this.#OnUpdateObjective(ev.data);
         });
     }
 
-    emit(data) {
-        console.log(`Emitting: ${data}`);
-
+    emit(type, payload) {
         // Add the user to the data for tracking who sent the data.
-        data.user = game.user;
+        payload.user = game.user;
 
         const sock = game.socket;
-        if (sock) return sock.emit(this.identifier, data);
+        if (sock)
+            return sock.emit(this.identifier, { type: type, data: payload });
     }
 
     #OnInsertOrUpdate(data) {
+        // If the user isn't a GM, ignore.
         if (!game.user.isGM) return;
 
-        console.log(`Received quest data: ${data}`);
+        // If the quest is a GM quest but players aren't allowed
+        // to edit GM quests, don't allow the edit.
+        if (data.GMQuest && !Settings.get(Settings.NAMES.PLAYER_EDIT)) return;
+
+        console.log(`User ${data.user.id} has edited quest ${data.questId}`);
         let q = new Quest(data);
         QuestDatabase.InsertOrUpdate(q);
-        console.log(q);
         UIManager.tracker.render();
     }
 
+    #OnDeleteQuest(data) {
+        // If the user isn't a GM, ignore.
+        if (!game.user.isGM) return;
+
+        // If the quest is a GM quest, players cannot delete it.
+        if (data.GMQuest) return;
+
+        console.log(`User ${data.user.id} has deleted quest ${data.questId}`);
+        QuestDatabase.removeQuest(data.questId);
+    }
+
     #OnUpdateObjective(data) {
+        // If the user isn't a GM, ignore.
+        if (!game.user.isGM) return;
+
+        // Get the quest
+        var Q = QuestDatabase.getQuest(data.questId);
+
+        // If the quest is a GM quest but players aren't allowed
+        // to mark GM quests, don't allow the mark.
+        if (Q.GMQuest && !Settings.get(Settings.NAMES.PLAYER_MARK)) return;
+
+        console.log(
+            `User ${data.user.id} has marked quest ${data.questId} objective ${data.objId}`
+        );
         Quest.updateObjective(data.questId, data.objId, "state");
     }
 }

--- a/scripts/helpers/SocketHandler.js
+++ b/scripts/helpers/SocketHandler.js
@@ -1,4 +1,7 @@
 import { constants } from "./global.js";
+import { Quest } from "../data/quest.js";
+import { QuestDatabase } from "../data/database.js";
+import { UIManager } from "../ui/ui-manager.js";
 
 export class SocketHandler {
     identifier = `module.simpler-quests`;
@@ -8,8 +11,8 @@ export class SocketHandler {
     }
 
     registerSocketListeners() {
-        game.socket?.on(this.identifier, (data) => {
-            console.log(data);
+        game.socket?.on(this.identifier, (ev) => {
+            if (ev.type === "InsertOrUpdate") this.#OnQuestEdit(ev.data);
         });
     }
 
@@ -17,5 +20,15 @@ export class SocketHandler {
         console.log(`Emitting: ${data}`);
         const sock = game.socket;
         if (sock) return sock.emit(this.identifier, data);
+    }
+
+    #OnQuestEdit(data) {
+        if (!game.user.isGM) return;
+
+        console.log(`Received quest data: ${data}`);
+        let q = new Quest(data);
+        QuestDatabase.InsertOrUpdate(q);
+        console.log(q);
+        UIManager.tracker.render();
     }
 }

--- a/scripts/helpers/SocketHandler.js
+++ b/scripts/helpers/SocketHandler.js
@@ -20,6 +20,10 @@ export class SocketHandler {
 
     emit(data) {
         console.log(`Emitting: ${data}`);
+
+        // Add the user to the data for tracking who sent the data.
+        data.user = game.user;
+
         const sock = game.socket;
         if (sock) return sock.emit(this.identifier, data);
     }

--- a/scripts/helpers/SocketHandler.js
+++ b/scripts/helpers/SocketHandler.js
@@ -12,7 +12,7 @@ export class SocketHandler {
 
     registerSocketListeners() {
         game.socket?.on(this.identifier, (ev) => {
-            if (ev.type === "InsertOrUpdate") this.#OnQuestEdit(ev.data);
+            if (ev.type === "InsertOrUpdate") this.#OnInsertOrUpdate(ev.data);
             else if (ev.type == "UpdateObjective")
                 this.#OnUpdateObjective(ev.data);
         });
@@ -24,7 +24,7 @@ export class SocketHandler {
         if (sock) return sock.emit(this.identifier, data);
     }
 
-    #OnQuestEdit(data) {
+    #OnInsertOrUpdate(data) {
         if (!game.user.isGM) return;
 
         console.log(`Received quest data: ${data}`);

--- a/scripts/helpers/SocketHandler.js
+++ b/scripts/helpers/SocketHandler.js
@@ -13,6 +13,8 @@ export class SocketHandler {
     registerSocketListeners() {
         game.socket?.on(this.identifier, (ev) => {
             if (ev.type === "InsertOrUpdate") this.#OnQuestEdit(ev.data);
+            else if (ev.type == "UpdateObjective")
+                this.#OnUpdateObjective(ev.data);
         });
     }
 
@@ -30,5 +32,9 @@ export class SocketHandler {
         QuestDatabase.InsertOrUpdate(q);
         console.log(q);
         UIManager.tracker.render();
+    }
+
+    #OnUpdateObjective(data) {
+        Quest.updateObjective(data.questId, data.objId, "state");
     }
 }

--- a/scripts/helpers/SocketHandler.js
+++ b/scripts/helpers/SocketHandler.js
@@ -1,0 +1,21 @@
+import { constants } from "./global.js";
+
+export class SocketHandler {
+    identifier = `module.simpler-quests`;
+
+    constructor() {
+        this.registerSocketListeners();
+    }
+
+    registerSocketListeners() {
+        game.socket?.on(this.identifier, (data) => {
+            console.log(data);
+        });
+    }
+
+    emit(data) {
+        console.log(`Emitting: ${data}`);
+        const sock = game.socket;
+        if (sock) return sock.emit(this.identifier, data);
+    }
+}

--- a/scripts/helpers/global.js
+++ b/scripts/helpers/global.js
@@ -30,3 +30,11 @@ export function gmCheck() {
     }
     return true;
 }
+
+var _sock;
+export function getSocket() {
+    return _sock;
+}
+export function setSocket(socket) {
+    _sock = socket;
+}

--- a/scripts/helpers/settings.js
+++ b/scripts/helpers/settings.js
@@ -16,6 +16,8 @@ export class Settings {
         TRACKER_OPEN: "trackerWindowOpen",
         TRACKER_HIDE: "trackerHideFromPlayers",
         PLAYER_EDIT: "playersEditQuest",
+        PLAYER_CREATE: "playersCreateQuest",
+        PLAYER_MARK: "playersMarkObjectives",
     });
 
     static registerSettings() {
@@ -40,6 +42,26 @@ export class Settings {
         game.settings.register(constants.moduleName, this.NAMES.PLAYER_EDIT, {
             name: "SimplerQuests.Settings.PlayerEdit.Name",
             hint: "SimplerQuests.Settings.PlayerEdit.Hint",
+            scope: "world",
+            type: Boolean,
+            default: false,
+            config: true,
+            requiresReload: true,
+        });
+
+        game.settings.register(constants.moduleName, this.NAMES.PLAYER_CREATE, {
+            name: "SimplerQuests.Settings.PlayerCreate.Name",
+            hint: "SimplerQuests.Settings.PlayerCreate.Hint",
+            scope: "world",
+            type: Boolean,
+            default: false,
+            config: true,
+            requiresReload: true,
+        });
+
+        game.settings.register(constants.moduleName, this.NAMES.PLAYER_MARK, {
+            name: "SimplerQuests.Settings.PlayersMark.Name",
+            hint: "SimplerQuests.Settings.PlayersMark.Hint",
             scope: "world",
             type: Boolean,
             default: false,

--- a/scripts/helpers/settings.js
+++ b/scripts/helpers/settings.js
@@ -39,9 +39,9 @@ export class Settings {
             requiresReload: true,
         });
 
-        game.settings.register(constants.moduleName, this.NAMES.PLAYER_EDIT, {
-            name: "SimplerQuests.Settings.PlayerEdit.Name",
-            hint: "SimplerQuests.Settings.PlayerEdit.Hint",
+        game.settings.register(constants.moduleName, this.NAMES.PLAYER_CREATE, {
+            name: "SimplerQuests.Settings.PlayerCreate.Name",
+            hint: "SimplerQuests.Settings.PlayerCreate.Hint",
             scope: "world",
             type: Boolean,
             default: false,
@@ -49,9 +49,9 @@ export class Settings {
             requiresReload: true,
         });
 
-        game.settings.register(constants.moduleName, this.NAMES.PLAYER_CREATE, {
-            name: "SimplerQuests.Settings.PlayerCreate.Name",
-            hint: "SimplerQuests.Settings.PlayerCreate.Hint",
+        game.settings.register(constants.moduleName, this.NAMES.PLAYER_EDIT, {
+            name: "SimplerQuests.Settings.PlayerEdit.Name",
+            hint: "SimplerQuests.Settings.PlayerEdit.Hint",
             scope: "world",
             type: Boolean,
             default: false,

--- a/scripts/helpers/settings.js
+++ b/scripts/helpers/settings.js
@@ -15,6 +15,7 @@ export class Settings {
         TRACKER_POS: "trackerWindowPosition",
         TRACKER_OPEN: "trackerWindowOpen",
         TRACKER_HIDE: "trackerHideFromPlayers",
+        PLAYER_EDIT: "playersEditQuest",
     });
 
     static registerSettings() {
@@ -29,6 +30,16 @@ export class Settings {
         game.settings.register(constants.moduleName, this.NAMES.TRACKER_HIDE, {
             name: "SimplerQuests.Settings.TrackerHidden.Name",
             hint: "SimplerQuests.Settings.TrackerHidden.Hint",
+            scope: "world",
+            type: Boolean,
+            default: false,
+            config: true,
+            requiresReload: true,
+        });
+
+        game.settings.register(constants.moduleName, this.NAMES.PLAYER_EDIT, {
+            name: "SimplerQuests.Settings.PlayerEdit.Name",
+            hint: "SimplerQuests.Settings.PlayerEdit.Hint",
             scope: "world",
             type: Boolean,
             default: false,

--- a/scripts/init.js
+++ b/scripts/init.js
@@ -3,6 +3,8 @@ import { UIManager } from "./ui/ui-manager.js";
 import { Settings } from "./helpers/settings.js";
 import { HandlebarHelper } from "./helpers/handlebars.js";
 import { SimplerQuestsAPI } from "./api.js";
+import { setSocket } from "./helpers/global.js";
+import { SocketHandler } from "./helpers/socketHandler.js";
 
 Hooks.once("init", (opts) => {
     // Start by registering the module settings.
@@ -13,6 +15,8 @@ Hooks.once("init", (opts) => {
 
     // Prepare the quest tracker.
     UIManager.init();
+
+    setSocket(new SocketHandler());
 });
 
 Hooks.on("ready", async () => {

--- a/scripts/ui/questeditor.js
+++ b/scripts/ui/questeditor.js
@@ -118,10 +118,7 @@ export class QuestEditor extends Application {
                 UIManager.tracker.render();
                 this.close();
             } else {
-                getSocket().emit({
-                    type: "InsertOrUpdate",
-                    data: qData,
-                });
+                getSocket().emit("InsertOrUpdate", qData);
                 UIManager.tracker.render();
                 this.close();
             }

--- a/scripts/ui/questeditor.js
+++ b/scripts/ui/questeditor.js
@@ -1,4 +1,4 @@
-import { constants, objectiveState } from "../helpers/global.js";
+import { constants, getSocket, objectiveState } from "../helpers/global.js";
 import { QuestDatabase } from "../data/database.js";
 import { Quest } from "../data/quest.js";
 import { Objective } from "../data/objective.js";
@@ -94,18 +94,30 @@ export class QuestEditor extends Application {
                 .find("#objective-display-select > .selection-bar > .body")
                 .data("value");
 
-            let q = new Quest({
+            // Prepare the quest data
+            let qData = {
                 id: this.quest.id,
                 title: title,
                 objectives: objs,
                 viewStyle: selectBody,
                 visible: this.quest.visible,
-            });
+            };
 
-            QuestDatabase.InsertOrUpdate(q);
-            console.log(q);
-            UIManager.tracker.render();
-            this.close();
+            // If the user is the GM then save the quest
+            // TODO Flip this by removing the !
+            if (!game.user.isGM) {
+                let q = new Quest(qData);
+
+                QuestDatabase.InsertOrUpdate(q);
+                console.log(q);
+                UIManager.tracker.render();
+                this.close();
+            } else {
+                getSocket().emit({
+                    type: "InsertOrUpdate",
+                    data: qData,
+                });
+            }
         });
 
         // Quest visibility toggle.

--- a/scripts/ui/questeditor.js
+++ b/scripts/ui/questeditor.js
@@ -105,7 +105,7 @@ export class QuestEditor extends Application {
 
             // If the user is the GM then save the quest
             // TODO Flip this by removing the !
-            if (!game.user.isGM) {
+            if (game.user.isGM) {
                 let q = new Quest(qData);
 
                 QuestDatabase.InsertOrUpdate(q);

--- a/scripts/ui/questeditor.js
+++ b/scripts/ui/questeditor.js
@@ -105,6 +105,7 @@ export class QuestEditor extends Application {
                 objectives: objs,
                 viewStyle: selectBody,
                 visible: this.quest.visible,
+                GMQuest: this.quest.GMQuest,
             };
 
             // If the user is the GM then save the quest

--- a/scripts/ui/questeditor.js
+++ b/scripts/ui/questeditor.js
@@ -33,6 +33,7 @@ export class QuestEditor extends Application {
             }
         } else {
             this.#quest = new Quest();
+            if (!game.user.isGM) this.#quest.visible = true;
         }
     }
 
@@ -117,6 +118,8 @@ export class QuestEditor extends Application {
                     type: "InsertOrUpdate",
                     data: qData,
                 });
+                UIManager.tracker.render();
+                this.close();
             }
         });
 
@@ -136,6 +139,7 @@ export class QuestEditor extends Application {
             Settings.get(Settings.NAMES.QUEST_VIEW_STYLE);
 
         return foundry.utils.mergeObject(super.getData(), {
+            isGM: game.user.isGM,
             title: "Quest Editor Test",
             questTitle: this.quest.title,
             objectives: Quest.stringify(this.quest),

--- a/scripts/ui/questeditor.js
+++ b/scripts/ui/questeditor.js
@@ -33,7 +33,10 @@ export class QuestEditor extends Application {
             }
         } else {
             this.#quest = new Quest();
-            if (!game.user.isGM) this.#quest.visible = true;
+            if (!game.user.isGM) {
+                this.#quest.visible = true;
+                this.#quest.GMQuest = false;
+            }
         }
     }
 

--- a/scripts/ui/questtracker.js
+++ b/scripts/ui/questtracker.js
@@ -93,6 +93,8 @@ export class QuestTracker extends Application {
             quests: QuestDatabase.quests,
             isGM: game.user.isGM,
             canEdit: game.user.isGM || Settings.get(Settings.NAMES.PLAYER_EDIT),
+            canCreate:
+                game.user.isGM || Settings.get(Settings.NAMES.PLAYER_CREATE),
             activeQuests: this.activeQuests,
             offset: `${Settings.get(Settings.NAMES.TRACKER_OFFSET) / 16}rem`,
             docked: Settings.get(Settings.NAMES.TRACKER_DOCKED),

--- a/scripts/ui/questtracker.js
+++ b/scripts/ui/questtracker.js
@@ -1,4 +1,4 @@
-import { constants } from "../helpers/global.js";
+import { constants, getSocket } from "../helpers/global.js";
 import { QuestDatabase } from "../data/database.js";
 import { QuestEditor } from "./questeditor.js";
 import { objectiveState } from "../helpers/global.js";
@@ -146,6 +146,8 @@ export class QuestTracker extends Application {
         $html.find(".minimize").on("click", (evt) => {
             evt.stopPropagation();
             this.collapse();
+            let result = getSocket().emit({ type: "TEST" });
+            console.log(result);
         });
 
         // Expand/Collapse quest bodies.

--- a/scripts/ui/questtracker.js
+++ b/scripts/ui/questtracker.js
@@ -92,6 +92,7 @@ export class QuestTracker extends Application {
             collapsed: this.collapsed,
             quests: QuestDatabase.quests,
             isGM: game.user.isGM,
+            canEdit: game.user.isGM || Settings.get(Settings.NAMES.PLAYER_EDIT),
             activeQuests: this.activeQuests,
             offset: `${Settings.get(Settings.NAMES.TRACKER_OFFSET) / 16}rem`,
             docked: Settings.get(Settings.NAMES.TRACKER_DOCKED),
@@ -193,7 +194,9 @@ export class QuestTracker extends Application {
         });
 
         // All of the listeners beyond this point are for the GM only.
-        if (!game.user.isGM) return;
+        if (!game.user.isGM && !Settings.get(Settings.NAMES.PLAYER_EDIT))
+            return;
+
         // Progress the state of an objective.
         $html.find(".simpler-quest-objective").on("click", (evt) => {
             evt.stopPropagation();

--- a/scripts/ui/ui-manager.js
+++ b/scripts/ui/ui-manager.js
@@ -69,7 +69,8 @@ export class UIManager {
             buttons[0].tooltip = buttons[0].label;
             buttons[0].label = null;
 
-            if (game.user.isGM) buttons.unshift(...UIManager.headerButtons);
+            if (game.user.isGM || Settings.get(Settings.NAMES.PLAYER_CREATE))
+                buttons.unshift(...UIManager.headerButtons);
         }
     }
 }

--- a/templates/editor.hbs
+++ b/templates/editor.hbs
@@ -9,6 +9,7 @@
             data-quest-id="{{this.id}}"
             value="{{this.questTitle}}"
         />
+        {{#if this.isGM}}
         <div class="quest-visibility">
             {{#if this.visible}}
                 <i class="fa-solid fa-eye" title="{{localize 'SimplerQuests.Common.Visible'}}"></i>
@@ -16,6 +17,7 @@
                 <i class="fa-solid fa-eye-slash" title="{{localize 'SimplerQuests.Common.Hidden'}}"></i>
             {{/if}}
         </div>
+        {{/if}}
     </div>
     <div class="view-style-wrapper">
         <div id="objective-display-select" class="select" tabindex="2">

--- a/templates/tracker-body.hbs
+++ b/templates/tracker-body.hbs
@@ -14,6 +14,8 @@
                 {{/if}}
                 {{#if canEdit}}
                     <div class="edit" title="{{localize 'SimplerQuests.Tracker.Edit'}}"><i class="fa-solid fa-pen-to-square"></i></div>
+                {{/if}}
+                {{#if canDelete}}
                     <div class="delete" title="{{localize 'SimplerQuests.Tracker.Delete'}}"><i class="fa-solid fa-trash"></i></div>
                 {{/if}}
             </div>

--- a/templates/tracker-body.hbs
+++ b/templates/tracker-body.hbs
@@ -6,10 +6,12 @@
                 <i class="fa-solid fa-caret-right{{#if (simplerQuestIsActiveQuest ../activeQuests this.id)}} fa-rotate-90{{/if}}"></i>
                 <h3>{{this.title}}</h3>
                 {{#if ../canEdit}}
-                    {{#if this.visible}}
-                        <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Visible'}}"><i class="fa-solid fa-eye"></i></div>
-                    {{else}}
-                        <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Hidden'}}"><i class="fa-solid fa-eye-slash"></i></div>
+                    {{#if ../isGM}}
+                        {{#if this.visible}}
+                            <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Visible'}}"><i class="fa-solid fa-eye"></i></div>
+                        {{else}}
+                            <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Hidden'}}"><i class="fa-solid fa-eye-slash"></i></div>
+                        {{/if}}
                     {{/if}}
                     <div class="edit" title="{{localize 'SimplerQuests.Tracker.Edit'}}"><i class="fa-solid fa-pen-to-square"></i></div>
                     <div class="delete" title="{{localize 'SimplerQuests.Tracker.Delete'}}"><i class="fa-solid fa-trash"></i></div>

--- a/templates/tracker-body.hbs
+++ b/templates/tracker-body.hbs
@@ -5,14 +5,14 @@
             <div class="header">
                 <i class="fa-solid fa-caret-right{{#if (simplerQuestIsActiveQuest ../activeQuests this.id)}} fa-rotate-90{{/if}}"></i>
                 <h3>{{this.title}}</h3>
-                {{#if ../canEdit}}
-                    {{#if ../isGM}}
-                        {{#if this.visible}}
-                            <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Visible'}}"><i class="fa-solid fa-eye"></i></div>
-                        {{else}}
-                            <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Hidden'}}"><i class="fa-solid fa-eye-slash"></i></div>
-                        {{/if}}
+                {{#if ../isGM}}
+                    {{#if this.visible}}
+                        <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Visible'}}"><i class="fa-solid fa-eye"></i></div>
+                    {{else}}
+                        <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Hidden'}}"><i class="fa-solid fa-eye-slash"></i></div>
                     {{/if}}
+                {{/if}}
+                {{#if canEdit}}
                     <div class="edit" title="{{localize 'SimplerQuests.Tracker.Edit'}}"><i class="fa-solid fa-pen-to-square"></i></div>
                     <div class="delete" title="{{localize 'SimplerQuests.Tracker.Delete'}}"><i class="fa-solid fa-trash"></i></div>
                 {{/if}}

--- a/templates/tracker-body.hbs
+++ b/templates/tracker-body.hbs
@@ -5,7 +5,7 @@
             <div class="header">
                 <i class="fa-solid fa-caret-right{{#if (simplerQuestIsActiveQuest ../activeQuests this.id)}} fa-rotate-90{{/if}}"></i>
                 <h3>{{this.title}}</h3>
-                {{#if ../isGM}}
+                {{#if ../canEdit}}
                     {{#if this.visible}}
                         <div class="vis-toggle" title="{{localize 'SimplerQuests.Common.Visible'}}"><i class="fa-solid fa-eye"></i></div>
                     {{else}}

--- a/templates/tracker-dock.hbs
+++ b/templates/tracker-dock.hbs
@@ -6,7 +6,7 @@
     {{else}}
         <div class="header">
             <h3>{{localize 'SimplerQuests.Tracker.ActiveQuests'}}</h3>
-            {{#if isGM}}
+            {{#if canCreate}}
                 <div class="new-quest" title="{{localize 'SimplerQuests.Tracker.AddQuest'}}"><i class="fa-solid fa-plus"></i></div>
             {{/if}}
             <div class="minimize" title="{{localize 'SimplerQuests.Tracker.Minimize'}}"><i class="fa-solid fa-window-minimize"></i></div>


### PR DESCRIPTION
# Changes
Added 3 new settings to allow players to create, modify, and mark quests. This gives GMs the power to grant some levels of quest tracking control to the players.